### PR TITLE
Fix keywords formatting

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,30 +28,10 @@ paginate     = 8
 [languages]
   [languages.en]
     languageName           = "English"
-    title                  = "Paige Thompson's official web site and blog - paige.bio"
+    title                  = "Paige Thompson's official web site and blog"
     subtitle               = "News / Contact Info / Projects / Free Information"
     owner                  = "Paige Thompson"
-    keywords               = [
-      "Computers", 
-      "Programming", 
-      "Seattle", 
-      "Internet Art", 
-      "Information Security",
-      "Defcon",
-      "Hushcon",
-      "ANSI",
-      "Consulting", 
-      "Networking", 
-      "Coaching", 
-      "Reviews", 
-      "Electronics", 
-      "Wireless",
-      "Cryptography",
-      "Development",
-      "Good faith hacking",
-      "Social Networking", 
-      "Cycling",
-      "Hobbies"]
+    keywords               = "Computers, Programming, Seattle, Internet Art, Information Security, Defcon, Hushcon, ANSI, Consulting, Networking, Coaching, Reviews, Electronics, Wireless, Cryptography, Development, Good faith hacking, Social Networking, Cycling, Hobbies"
     copyright              = "2023"
     menuMore               = "Show more"
     readMore               = "Read more"


### PR DESCRIPTION
toml didn't un-marshal array to comma separated string, made keywords a comma separated string. 